### PR TITLE
fix(major): [sc-6843] Propagate HTTP error as code instead of string to ease handling.

### DIFF
--- a/Sources/ConsulServiceDiscovery/Service.swift
+++ b/Sources/ConsulServiceDiscovery/Service.swift
@@ -7,18 +7,17 @@ public struct Service: Codable {
     /// `healthSyncContainers`.
     let checks: [Check]?
     /// Specifies a unique ID for this service.
-    let id: String?
+    let id: String
     /// Key-value pairs of metadata to include for the Consul service.
     let meta: [String: String]?
-    /// The name the service will be registered as in Consul. Defaults to the Task family name if
-    /// empty or null.
-    let name: String?
+    /// The name the service will be registered as in Consul.
+    let name: String
     /// Port the application listens on, if any.
     let port: Int?
     /// List of string values that can be used to add service-level labels.
     let tags: [String]?
 
-    public init(address: String? = nil, checks: [Check]? = nil, id: String? = nil, meta: [String: String]? = nil, name: String? = nil, port: Int? = nil, tags: [String]? = nil) {
+    public init(address: String? = nil, checks: [Check]? = nil, id: String, meta: [String: String]? = nil, name: String, port: Int? = nil, tags: [String]? = nil) {
         self.address = address
         self.checks = checks
         self.id = id
@@ -45,7 +44,7 @@ public struct Check: Codable {
     /// Specifies that checks associated with a service should deregister after this time.
     let deregisterCriticalServiceAfter: String?
     /// The name of the check.
-    let name: String?
+    let name: String
     /// Specifies the initial status the health check.
     let status: Status?
     /// Specifies a timeout for outgoing connections. Applies to script, HTTP, TCP, UDP, and gRPC
@@ -54,7 +53,7 @@ public struct Check: Codable {
     /// Specifies this is a TTL check. Must be a duration string, such as `10s` or `5m`.
     let ttl: String?
 
-    public init(checkID: String? = nil, deregisterCriticalServiceAfter: String? = nil, name: String? = nil, status: Status? = nil, timeout: String? = nil, ttl: String? = nil) {
+    public init(checkID: String? = nil, deregisterCriticalServiceAfter: String? = nil, name: String, status: Status? = nil, timeout: String? = nil, ttl: String? = nil) {
         self.checkID = checkID
         self.deregisterCriticalServiceAfter = deregisterCriticalServiceAfter
         self.name = name

--- a/Tests/ConsulServiceDiscoveryTests/ConsulServiceDiscoveryTests.swift
+++ b/Tests/ConsulServiceDiscoveryTests/ConsulServiceDiscoveryTests.swift
@@ -45,10 +45,10 @@ final class ConsulServiceDiscoveryTests: XCTestCase {
 
         try lookupDone.futureResult.wait()
 
-        let deregisterFuture1 = consul.agent.deregisterServiceID(service1.id!)
+        let deregisterFuture1 = consul.agent.deregisterServiceID(service1.id)
         try deregisterFuture1.wait()
 
-        let deregisterFuture2 = consul.agent.deregisterServiceID(service2.id!)
+        let deregisterFuture2 = consul.agent.deregisterServiceID(service2.id)
         try deregisterFuture2.wait()
 
         try eventLoopGroup.syncShutdownGracefully()
@@ -99,7 +99,7 @@ final class ConsulServiceDiscoveryTests: XCTestCase {
         try done.futureResult.wait()
         cancellationToken.cancel()
 
-        let deregisterFuture = consul.agent.deregisterServiceID(service.id!)
+        let deregisterFuture = consul.agent.deregisterServiceID(service.id)
         try deregisterFuture.wait()
 
         try eventLoopGroup.syncShutdownGracefully()

--- a/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
+++ b/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
@@ -36,10 +36,7 @@ final class ConsulTests: XCTestCase {
 
         let checkID = "service:\(serviceID)"
         let future = consul.agent.check(checkID, status: .passing)
-
-        var continuation: AsyncStream<Result<Void, Error>>.Continuation?
-        let stream = AsyncStream<Result<Void, Error>>() { continuation = $0 }
-        guard let continuation else { fatalError("continuation unexpectedly nil") }
+        let (stream, continuation) = AsyncStream.makeStream(of: Result<Void, Error>.self)
 
         future.whenComplete { result in
             continuation.yield(result)

--- a/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
+++ b/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
@@ -51,7 +51,7 @@ final class ConsulTests: XCTestCase {
                 XCTFail("check update unexpectedly succeeded")
             case let .failure(error):
                 if let error = error as? ConsulError,
-                   case let .responseError(responseStatus) = error,
+                   case let .httpResponseError(responseStatus) = error,
                    responseStatus == .notFound {
                     // expected error
                 } else {

--- a/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
+++ b/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
@@ -27,6 +27,7 @@ final class ConsulTests: XCTestCase {
     }
 
     func testHealthCheckError() async throws {
+        // Try to update health status for service which has not been registered.
         let consul = Consul()
 
         let serviceName = "test_service"


### PR DESCRIPTION
## Description

Propagate HTTP error as code instead of string to ease handling.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
