### PR TITLE
fix(patch): [sc-3261] Populate tagged addresses in node service.

### DIFF
--- a/Sources/ConsulServiceDiscovery/Consul.swift
+++ b/Sources/ConsulServiceDiscovery/Consul.swift
@@ -160,7 +160,7 @@ public final class Consul: Sendable {
         /// - Parameters
         ///    - datacenter: Specifies the datacenter to query. This will default to the datacenter of the agent being queried.
         ///    - serviceName: Specifies the name of the service for which to list nodes.
-        /// - Returns: EventLoopFuture<[NodeService]> to deliver result
+        /// - Returns: EventLoopFuture<(Int, [NodeService])> to deliver result where first element of tuple is value of "X-Consul-Index" from HTTP header
         /// [apidoc]: https://developer.hashicorp.com/consul/api-docs/catalog#list-nodes-for-service
         ///
         public func nodes(inDatacenter datacenter: String? = nil,

--- a/Sources/ConsulServiceDiscovery/Service.swift
+++ b/Sources/ConsulServiceDiscovery/Service.swift
@@ -114,8 +114,9 @@ public struct NodeService: Hashable, Decodable, Sendable {
     public let serviceMeta: [String: String]?
     public let serviceName: String?
     public let servicePort: Int?
+    public let taggedAddresses: [String: String]?
 
-    public init(address: String? = nil, createIndex: Int? = nil, datacenter: String? = nil, id: String? = nil, modifyIndex: Int? = nil, node: String? = nil, serviceAddress: String? = nil, serviceID: String, serviceMeta: [String: String]? = nil, serviceName: String? = nil, servicePort: Int? = nil) {
+    public init(address: String? = nil, createIndex: Int? = nil, datacenter: String? = nil, id: String? = nil, modifyIndex: Int? = nil, node: String? = nil, serviceAddress: String? = nil, serviceID: String, serviceMeta: [String: String]? = nil, serviceName: String? = nil, servicePort: Int? = nil, taggedAddresses: [String: String]? = nil) {
         self.address = address
         self.createIndex = createIndex
         self.datacenter = datacenter
@@ -127,6 +128,7 @@ public struct NodeService: Hashable, Decodable, Sendable {
         self.serviceMeta = serviceMeta
         self.serviceName = serviceName
         self.servicePort = servicePort
+        self.taggedAddresses = taggedAddresses
     }
 
     public enum CodingKeys: String, CodingKey {
@@ -141,6 +143,7 @@ public struct NodeService: Hashable, Decodable, Sendable {
         case serviceMeta = "ServiceMeta"
         case serviceName = "ServiceName"
         case servicePort = "ServicePort"
+        case taggedAddresses = "TaggedAddresses"
     }
 }
 

--- a/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
+++ b/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
@@ -16,9 +16,18 @@ final class ConsulTests: XCTestCase {
         let registerFuture = consul.agent.registerService(service)
         try registerFuture.wait()
 
-        let servicesFuture = consul.catalog.services()
-        let services = try servicesFuture.wait()
-        XCTAssertTrue(services.contains(where: { $0 == serviceName }))
+        do {
+            let servicesFuture = consul.catalog.services()
+            let services = try servicesFuture.wait()
+            XCTAssertTrue(services.contains(where: { $0 == serviceName }))
+        }
+
+        do {
+            let nodesFuture = consul.catalog.nodes(withService: serviceName)
+            let (_, services) = try nodesFuture.wait()
+            let service = services.first(where: { ($0.serviceName == serviceName) && ($0.serviceID == serviceID) })
+            XCTAssertNotNil(service)
+        }
 
         let deregisterFuture = consul.agent.deregisterServiceID(serviceID)
         try deregisterFuture.wait()


### PR DESCRIPTION
## Description

Populate tagged addresses in node service.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
