### PR TITLE
fix(patch): [sc-8508] Do not break service discovery if consul server does not respond.

### DIFF
--- a/Sources/ConsulServiceDiscovery/Consul.swift
+++ b/Sources/ConsulServiceDiscovery/Consul.swift
@@ -11,12 +11,14 @@ public enum ConsulError: Error {
     case error(String)
 }
 
-private protocol ConsulResponseHandler: Sendable {
+protocol ConsulResponseHandler: Sendable {
     func processResponse(_ buffer: ByteBuffer, withIndex: Int?)
     func fail(_ error: Error)
 }
 
 public final class Consul: Sendable {
+    static let reconnectInterval: TimeAmount = .seconds(5)
+
     public static var defaultHost: String {
         let defaultHost = "127.0.0.1"
 
@@ -401,7 +403,7 @@ public final class Consul: Sendable {
         public let wait: String?
     }
 
-    private let impl: Impl
+    let impl: Impl
 
     public let agent: Agent
     public let catalog: Catalog
@@ -412,7 +414,7 @@ public final class Consul: Sendable {
         set { impl.logger.logLevel = newValue }
     }
 
-    fileprivate final class Impl: Sendable {
+    final class Impl: Sendable {
         let serverHost: String
         let serverPort: Int
         let eventLoopGroup: EventLoopGroup

--- a/Sources/ConsulServiceDiscovery/ConsulServiceDiscovery.swift
+++ b/Sources/ConsulServiceDiscovery/ConsulServiceDiscovery.swift
@@ -45,6 +45,14 @@ public final class ConsulServiceDiscovery: ServiceDiscovery, Sendable {
                                    polling: poll)
                 case let .failure(error):
                     nextResultHandler(.failure(error))
+                    let eventLoop = self.consul.impl.eventLoopGroup.next()
+                    _ = eventLoop.scheduleTask(in: Consul.reconnectInterval) {
+                        self.subscribe(to: service,
+                                       onNext: nextResultHandler,
+                                       onCompletion: completionHandler,
+                                       cancellationToken: cancellationToken,
+                                       polling: nil)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

Do not break service discovery if consul server does not respond.

## How Has This Been Tested?

Unit and manual test.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
