### PR TITLE
fix(patch): Decode KV value from base 64 inside library.

### DIFF
--- a/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
+++ b/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
@@ -97,9 +97,7 @@ final class ConsulTests: XCTestCase {
         let value = try future3.wait()
 
         let valueValue = try XCTUnwrap(value.value, "value is unexpectedly empty")
-        let data = try XCTUnwrap(Data(base64Encoded: valueValue), "can't decode value")
-        let str = try XCTUnwrap(String(data: data, encoding: .utf8), "can't construct string")
-        XCTAssertEqual(str, testValue)
+        XCTAssertEqual(valueValue, testValue)
 
         let future4 = consul.kv.removeValue(forKey: testKey)
         try future4.wait()


### PR DESCRIPTION
## Description

Decode KV value from base 64 inside framework.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
