### PR TITLE
chore(patch): [sc-20934] Pass underlying NIO error message through ConsulError

### DIFF
--- a/Sources/ConsulServiceDiscovery/Consul.swift
+++ b/Sources/ConsulServiceDiscovery/Consul.swift
@@ -699,9 +699,9 @@ public final class Consul: Sendable {
 
                     switch error {
                     case let channelError as ChannelError:
-                        localizedDescription = channelError.localizedDescription
+                        localizedDescription = channelError.errorMessage
                     case let connectionError as NIOConnectionError:
-                        localizedDescription = connectionError.localizedDescription
+                        localizedDescription = connectionError.errorMessage
                     default:
                         localizedDescription = error.localizedDescription
                     }
@@ -906,7 +906,7 @@ private final class HTTPHandler: @unchecked Sendable, ChannelInboundHandler {
 }
 
 extension ChannelError {
-    var localizedDescription: String {
+    var errorMessage: String {
         switch self {
         case .connectPending:
             "Connect pending"
@@ -947,7 +947,7 @@ extension ChannelError {
 }
 
 extension NIOConnectionError {
-    var localizedDescription: String {
+    var errorMessage: String {
         if let dnsError = (dnsAError ?? dnsAAAAError) {
             return "DNS error: \(dnsError.localizedDescription)"
         }
@@ -955,7 +955,7 @@ extension NIOConnectionError {
         if !connectionErrors.isEmpty {
             let descriptions = connectionErrors.map {
                 if let channelError = $0.error as? ChannelError {
-                    channelError.localizedDescription
+                    channelError.errorMessage
                 } else {
                     $0.error.localizedDescription
                 }

--- a/Sources/ConsulServiceDiscovery/Consul.swift
+++ b/Sources/ConsulServiceDiscovery/Consul.swift
@@ -695,15 +695,10 @@ public final class Consul: Sendable {
                 }
                 .connect(host: serverHost, port: serverPort)
                 .whenFailure { error in
-                    let localizedDescription: String
-
-                    switch error {
-                    case let channelError as ChannelError:
-                        localizedDescription = channelError.errorMessage
-                    case let connectionError as NIOConnectionError:
-                        localizedDescription = connectionError.errorMessage
-                    default:
-                        localizedDescription = error.localizedDescription
+                    let localizedDescription = switch error {
+                    case let channelError as ChannelError: channelError.errorMessage
+                    case let connectionError as NIOConnectionError: connectionError.errorMessage
+                    default: error.localizedDescription
                     }
 
                     let message = "Failed to connect to consul API @ \(self.serverHost):\(self.serverPort): \(localizedDescription)"

--- a/Sources/ConsulServiceDiscovery/Consul.swift
+++ b/Sources/ConsulServiceDiscovery/Consul.swift
@@ -937,7 +937,7 @@ extension ChannelError {
         case let .illegalMulticastAddress(address):
             "Illegal multicast address \(address)"
         case let .multicastNotSupported(interface):
-            "Multipcast not supported on interface \(interface)"
+            "Multicast not supported on interface \(interface)"
         case .inappropriateOperationForState:
             "Inappropriate operation for state"
         case .unremovableHandler:


### PR DESCRIPTION
## Description

Currently we only get error messages like this on connection failure:

```
Failed to connect to consul API @ linux-dev:8500: The operation couldn't be completed. (NIOPosix.NIOConnectionError error 1.)
```

This change adds error messages to both `NIOConnectionError` and `ChannelError`.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
