### PR TITLE
feat(patch): [sc-29166] Add catalog datacenters() API

### DIFF
--- a/Sources/ConsulServiceDiscovery/Consul.swift
+++ b/Sources/ConsulServiceDiscovery/Consul.swift
@@ -189,6 +189,15 @@ public final class Consul: Sendable {
             }
         }
 
+        /// Returns the list of all known datacenters sorted by estimated median round trip time from the server to the servers in that datacenter.
+        /// https://developer.hashicorp.com/consul/api-docs/catalog#list-datacenters
+        public func datacenters() -> EventLoopFuture<[String]> {
+            let promise = impl.makePromise(of: [String].self)
+            let responseHandler = ResponseHandler(promise)
+            impl.request(method: .GET, uri: "/v1/catalog/datacenters", body: nil, handler: responseHandler)
+            return promise.futureResult
+        }
+
         /// Returns the nodes providing a service in a given datacenter.
         /// - Parameters
         ///    - datacenter: Specifies the datacenter to query. This will default to the datacenter of the agent being queried.

--- a/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
+++ b/Tests/ConsulServiceDiscoveryTests/ConsulTests.swift
@@ -13,6 +13,13 @@ final class ConsulTests: XCTestCase {
         try consul.syncShutdown()
     }
 
+    func testCatalogDatacenters() throws {
+        let consul = Consul()
+        let datacenters = try consul.catalog.datacenters().wait()
+        XCTAssertFalse(datacenters.isEmpty)
+        try consul.syncShutdown()
+    }
+
     func testRegisterDeregister() throws {
         let consul = Consul()
 


### PR DESCRIPTION
## Summary
- Add `datacenters()` method to `CatalogEndpoint` that queries `GET /v1/catalog/datacenters`
- Returns the list of all known datacenters sorted by estimated median round trip time
- Add `testCatalogDatacenters` test

## Test plan
- [ ] `swift build` compiles successfully
- [ ] `swift test` passes (requires running Consul instance)
- [ ] `testCatalogDatacenters` returns a non-empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)